### PR TITLE
Add support for authenticating with Github Enterprise

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -35,6 +35,7 @@ github = authom.createServer
   service: "github"
   id: nconf.get("oauth:github:id")
   secret: nconf.get("oauth:github:secret")
+  url: nconf.get("oauth:github:url")
   scope: ["gist"]
   
 staticOptions = 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "JSONStream": "0.4.x",
     "ace": "git://github.com/ajaxorg/ace#v1.2.2",
     "amd-loader": "0.0.5",
-    "authom": "https://github.com/ggoodman/authom/tarball/patch-1",
+    "authom": "0.4.36",
     "bluebird": "^2.2.2",
     "bluebird-lru-cache": "^0.1.0",
     "body-parser": "^1.5.2",


### PR DESCRIPTION
Upgrades Authom to use the built-in support for detection of the correct
backend according to the github url provided.
